### PR TITLE
Fix submodule download when SSH is not configured

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "resources/highRES-Europe-GAMS"]
 	path = resources/highRES-Europe-GAMS
-	url = git@github.com:highRES-model/highRES-Europe-GAMS.git
+	url = https://github.com/highRES-model/highRES-Europe-GAMS.git


### PR DESCRIPTION
Change to https URLs for the submodule because they work even if SSH is not configured.