### PR TITLE
[Env] Add git to dependencies

### DIFF
--- a/workflow/envs/highres_environment.yaml
+++ b/workflow/envs/highres_environment.yaml
@@ -25,6 +25,7 @@ dependencies:
   - pandas
   - shapely
   - matplotlib
+  - git
   - pip
   - pip:
     - cdsapi


### PR DESCRIPTION
Since we are now using submodules this requires git to be installed whenever changing the submodule code. Also pip installing directly from a branch in a repo requires this.


This will add git as a dependency as the pip download will fail if git is not installed. This could mean duplicate installs for everybody with git already installed.