### PR TITLE
[Bug] Update sjoins in new gpd version

### DIFF
--- a/workflow/notebooks/highRES_build_hydro.py.ipynb
+++ b/workflow/notebooks/highRES_build_hydro.py.ipynb
@@ -596,7 +596,7 @@
     "    # for a given plant. This may go away when we use a higher res nuts\n",
     "    # shapefile. For now, take nuts shapefile assignment.\n",
     "\n",
-    "    df_installed_ror = (gpd.sjoin(euro_nuts, df_installed_ror, op='contains')\n",
+    "    df_installed_ror = (gpd.sjoin(euro_nuts, df_installed_ror, predicate='contains')\n",
     "                    .reset_index()\n",
     "                    .loc[:,[\"index\",\"CNTR_CODE\",\"cap_mw\"]]\n",
     "                    .rename(columns={\"CNTR_CODE\":\"iso2\"}))\n",


### PR DESCRIPTION
With newer versions of geopandas, the "op" parameter of the sjoins function has been deprecated and replaced by the "predicate" parameter (https://geopandas.org/en/stable/docs/reference/api/geopandas.sjoin.html) . Anyone with a newer version of geopandas will run into errors of not being able to run the workflow on a nuts2 resolution as a result of this. 

A simple fix should be to just replace "op" with "predicate" in the build_hydro notebook. Thanks to @guillerval for identifying the fix. 

@James-Price Could you just verify that this change still works with your workflow? Seeing as you have not had the same issue, I would guess you are running an older version of geopandas. 