### PR TITLE
[Fix] Update environment and clc codes

### DIFF
--- a/workflow/envs/highres_environment.yaml
+++ b/workflow/envs/highres_environment.yaml
@@ -26,6 +26,7 @@ dependencies:
   - shapely
   - matplotlib
   - git
+  - rasterio=1.3.11
   - pip
   - pip:
     - cdsapi


### PR DESCRIPTION
At the current state, our workflow/builds on GitHub, and my workflow locally, breaks in rule build_vre_land_avail:

```
ValueError                                Traceback (most recent call last)
Cell In[22], line 1
----> 1 availability_matrix_solar = cutout.availabilitymatrix(
      2     europe, excluder_solar, nprocesses=snakemake.threads
      3 )

File ~/micromamba/envs/highres/lib/python3.12/site-packages/atlite/gis.py:756, in compute_availabilitymatrix(cutout, shapes, excluder, nprocesses, disable_progressbar)
    754 availability = np.stack(availability)[:, ::-1]  # flip axis, see Notes
    755 coords = [(shapes.index), ("y", cutout.data.y.data), ("x", cutout.data.x.data)]
--> 756 return xr.DataArray(availability, coords=coords)

File ~/micromamba/envs/highres/lib/python3.12/site-packages/xarray/core/dataarray.py:454, in DataArray.__init__(self, data, coords, dims, name, attrs, indexes, fastpath)
    452 data = _check_data_shape(data, coords, dims)
    453 data = as_compatible_data(data)
--> 454 coords, dims = _infer_coords_and_dims(data.shape, coords, dims)
    455 variable = Variable(dims, data, attrs, fastpath=True)
    457 if not isinstance(coords, Coordinates):

File ~/micromamba/envs/highres/lib/python3.12/site-packages/xarray/core/dataarray.py:146, in _infer_coords_and_dims(shape, coords, dims)
    139 """All the logic for creating a new DataArray"""
    141 if (
    142     coords is not None
    143     and not utils.is_dict_like(coords)
    144     and len(coords) != len(shape)
    145 ):
--> 146     raise ValueError(
    147         f"coords is not dict-like, but it has {len(coords)} items, "
    148         f"which does not match the {len(shape)} dimensions of the "
    149         "data"
    150     )
    152 if isinstance(dims, str):
    153     dims = (dims,)

ValueError: coords is not dict-like, but it has 3 items, which does not match the 4 dimensions of the data
```
This seems to be based on an update of rasterio, from 1.3.11 to 1.4.1. 

