### PR TITLE
[Config] Move choice of wind turbine to config

### DIFF
--- a/config/config_ci.yaml
+++ b/config/config_ci.yaml
@@ -104,6 +104,11 @@ parameters:
     2 : 1000,
     6 : 5000,
   }
+  windturbines : {
+    "onshore" : "Vestas_V112_3MW",
+    "offshore_bottom" : "NREL_ReferenceTurbine_2020ATB_5.5MW",
+    "offshore_float" : "NREL_ReferenceTurbine_2020ATB_5.5MW",
+  }
   co2target : [
     2 # gCO2/kWh
   ]

--- a/config/config_james.yaml
+++ b/config/config_james.yaml
@@ -105,6 +105,11 @@ parameters:
     2 : 1000,
     6 : 5000,
   }
+  windturbines : {
+    "onshore" : "Vestas_V112_3MW",
+    "offshore_bottom" : "NREL_ReferenceTurbine_2020ATB_5.5MW",
+    "offshore_float" : "NREL_ReferenceTurbine_2020ATB_5.5MW",
+  }
   co2target : [
     0 # gCO2/kWh
   ]

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -64,8 +64,6 @@ corine_codes = {
 
 windturbines = config["parameters"]["windturbines"]
 
-windturbines = config["parameters"]["windturbines"]
-
 scenarios = pd.DataFrame(inputyears, columns=["years"])
 
 concatlist = []

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -62,6 +62,10 @@ corine_codes = {
     "onwind_buffer": config["parameters"]["onwind_clc_buffer"],
 }
 
+windturbines = config["parameters"]["windturbines"]
+
+windturbines = config["parameters"]["windturbines"]
+
 scenarios = pd.DataFrame(inputyears, columns=["years"])
 
 concatlist = []
@@ -236,6 +240,7 @@ rule build_vre_cf_grid:
         sharedinputpath=shared_input_path,
         aggregated_regions=aggregated_regions,
         bias_correction=bias_correction,
+        windturbines=windturbines,
     notebook:
         "notebooks/highRES-build_vre_cf_grid.ipynb"
 

--- a/workflow/notebooks/highRES-build_vre_cf_grid.ipynb
+++ b/workflow/notebooks/highRES-build_vre_cf_grid.ipynb
@@ -21,9 +21,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "onshore_turbine = \"Vestas_V112_3MW\"\n",
-    "offshore_bottom_turbine = \"oedb:V164\"\n",
-    "offshore_floating_turbine = \"oedb:V164\"\n",
+    "onshore_turbine = snakemake.params.windturbines.get('onshore')\n",
+    "offshore_bottom_turbine = snakemake.params.windturbines.get('offshore_bottom')\n",
+    "offshore_floating_turbine = snakemake.params.windturbines.get('offshore_float')\n",
     "\n",
     "panel = \"CSi\"\n",
     "orientation = \"latitude_optimal\""
@@ -350,7 +350,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a small update that removes the hard coded wind turbines used (onshore, offshore floating & fixed) in rule build_vre_cf_grid. 

Due to the somewhat poor reliability of oedb, I also switched to a different turbine. We might want to discuss which one to provide as a default. 