### PR TITLE
[Feature] Allow using micromamba by including conda as dependency

### DIFF
--- a/workflow/envs/highres_environment.yaml
+++ b/workflow/envs/highres_environment.yaml
@@ -3,6 +3,8 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - conda # added here since some people might install using micromamba, but
+#             snakemake seems to require conda specifically.
   - python
   - jupyter
   - jupyterlab_code_formatter


### PR DESCRIPTION
Because snakemake requires conda, but we have not specified it as a dependency, the workflow fails to run in some situations where micromamba is used to build the environment.