### PR TITLE
Fix small problem of accepting existing nuclear, wind and solar capacity

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -354,6 +354,7 @@ rule build_vre_areas_file:
         areaswindon=rules.build_vre_cf_inputs.output.areaswindonshore,
         areaswindoff=rules.build_vre_cf_inputs.output.areaswindoffshore,
         data2dd=pathlib.Path(workflow.basedir) / "scripts",
+        technoeconomic_database="resources/highres_technoeconomic_database.ods",
     output:
         modelpath / "vre_areas_{year}_.dd",
         regionsdd=modelpath / "_regions.dd",

--- a/workflow/notebooks/highRES_build_vre_areas_file.ipynb
+++ b/workflow/notebooks/highRES_build_vre_areas_file.ipynb
@@ -49,9 +49,24 @@
    "source": [
     "areas[[\"tech\", \"zone\", \"region\"]] = areas[0].str.split(\".\", expand=True)\n",
     "\n",
-    "areas[\"region\"].drop_duplicates().to_csv(\n",
-    "    snakemake.output.regionsdd, index=False, header=None\n",
-    ")"
+    "# Add missing regions in exist_gen_r (only with nuts2 spatial option)\n",
+    "if snakemake.wildcards.spatial == \"nuts2\":\n",
+    "    excel_exist_pcap_r = pd.read_excel(\n",
+    "        snakemake.input.technoeconomic_database,\n",
+    "        sheet_name=\"gen_exist_r\",\n",
+    "        skiprows=0,\n",
+    "        engine=\"calamine\",\n",
+    "    )\n",
+    "    pd.concat([\n",
+    "        areas[\"region\"],\n",
+    "        excel_exist_pcap_r[\"region\"],\n",
+    "    ]).drop_duplicates().to_csv(\n",
+    "        snakemake.output.regionsdd, index=False, header=None\n",
+    "        )\n",
+    "else:\n",
+    "    areas[\"region\"].drop_duplicates().to_csv(\n",
+    "        snakemake.output.regionsdd, index=False, header=None\n",
+    "    )"
    ]
   }
  ],

--- a/workflow/scripts/data2dd_funcs.py
+++ b/workflow/scripts/data2dd_funcs.py
@@ -271,9 +271,11 @@ def getrlims(lim, techs, zones, exist_agg):
             )
 
         if exist_agg == "region":
-            limval = limval.groupby(["zone"], as_index=False).agg(
+            #limval = limval.groupby(["zone"], as_index=False).agg(
+            # to consider the other technologies
+            limval = limval.groupby(["Technology","zone"], as_index=False).agg(
                 {
-                    "Technology": "first",
+                    #"Technology": "first", # removed because is already in groupby
                     "Year": "first",
                     "parameter": "first",
                     "limtype": "first",


### PR DESCRIPTION
- Modified "build_vre_areas_file" rule to include dropped nuts2 regions. Dropped regions taken from the techno-economic database, gen_exist_r sheet.
- Modified "build_technoeconomic_inputs" rule (data2dd_funcs.py) to include all the technologies when they are grouped in "getrlims" function.