### PR TITLE
[CI] Update CI workflow to accommodate new GAMS version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get install wget curl
           cd ~
           pwd
-          wget https://d37drm4t2jghv5.cloudfront.net/distributions/46.5.0/linux/linux_x64_64_sfx.exe
+          wget https://d37drm4t2jghv5.cloudfront.net/distributions/49.4.0/linux/linux_x64_64_sfx.exe
           chmod 755 linux_x64_64_sfx.exe
           sudo mkdir /opt/gams
           cd /opt/gams
@@ -52,7 +52,7 @@ jobs:
           ~/linux_x64_64_sfx.exe
           cd ~
           pwd
-          ls /opt/gams/gams46.5_linux_x64_64_sfx
+          ls /opt/gams/gams49.4_linux_x64_64_sfx
 
       # Courtesy of PyPSA-EUR
       #- name: Setup secrets
@@ -62,10 +62,10 @@ jobs:
       # Courtesy of PyPSA-EUR
       - name: Setup GAMS license
         env:
-          GAMS_LICENSE: ${{ secrets.GAMS_LICENSE }}
+          GAMS_ACCESS_CODE: ${{ secrets.GAMS_ACCESS_CODE }}
         run: |
-          sudo -i
-          echo $GAMS_LICENSE | base64 --decode > /opt/gams/gams46.5_linux_x64_64_sfx/gamslice.txt
+          sudo /opt/gams/gams49.4_linux_x64_64_sfx/gamsgetkey $GAMS_ACCESS_CODE -o /opt/gams/gams49.4_linux_x64_64_sfx/gamslice.txt
+          
 
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v1

--- a/config/config_ci.yaml
+++ b/config/config_ci.yaml
@@ -1,7 +1,7 @@
 target: "results.db.compressed"
 
 paths:
-  gams: /opt/gams/gams46.5_linux_x64_64_sfx/
+  gams: /opt/gams/gams49.4_linux_x64_64_sfx/
   shared_input: shared_input
   abs_shared_code: /home/runner/work/highRES-Europe-WF/highRES-Europe-WF/resources/highRES-Europe-GAMS/
   results: work
@@ -36,34 +36,34 @@ parameters:
   pgen: 20.0
   date_range: ["01-01", "06-30"]
   aggregated_regions: [
-    #"AT",
+    "AT",
     #"BE",
-    "BG",
-    #"CH",
-    #"CZ",
-    #"DE",
+    #"BG",
+    "CH",
+    "CZ",
+    "DE",
     #"DK",
-    "EE",
-    "ES",
-    "FI",
+    #"EE",
+    #"ES",
+    #"FI",
     "FR",
-    "UK",
-    "GR",
-    "HR",
-    "HU",
-    "IE",
-    "IT",
-    "LT",
-    #"LU",
-    "LV",
+    #"UK",
+    #"GR",
+    #"HR",
+    #"HU",
+    #"IE",
+    #"IT",
+    #"LT",
+    "LU",
+    #"LV",
     #"NL",
-    "NO",
+    #"NO",
     "PL",
-    "PT",
-    "RO",
+    #"PT",
+    #"RO",
     #"SE",
     #"SI",
-    "SK",
+    #"SK",
   ]
   solar_clc : [
     1,

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -537,7 +537,7 @@ rule convert_results:
         resultsdb=ensure(protected(modelpath / "results.db"), non_empty=True),
     shell:
         # TODO platform independence
-        gamspath + "gdx2sqlite -i {input} -o {output} -fast"
+        gamspath + "gamstool sqlitewrite gdxIn={input} o={output}"
 
 
 rule convert_results_db_parquet:


### PR DESCRIPTION
With the latest version of GAMS (49.4) and the new handling of GAMS licenses, we need to update our automatic testing pipeline. 

Changes include:

- Add new GAMS access code as a secret variable
- Use the gamsgetkey feature to build the gamslice.txt file
- Decrease the number of countries in the CI to handle the 16GB of RAM on the GitHub hosted runners
- Replace gdx2sql with sqlitewrite to convert the resulting .gdx file to a .db file. 

The commit is split into three individual commits that should not be squashed. One for replacing gdx2sql with sqlitewrite, one for the new licence handling and one for decreasing the number of nodes. 