### PR TITLE
[ci] update atlite version

### DIFF
--- a/workflow/envs/highres_environment.yaml
+++ b/workflow/envs/highres_environment.yaml
@@ -6,6 +6,7 @@ dependencies:
   - conda # added here since some people might install using micromamba, but
 #             snakemake seems to require conda specifically.
   - python
+  - atlite
   - jupyter
   - jupyterlab_code_formatter
   - black
@@ -34,4 +35,3 @@ dependencies:
   - pip
   - pip:
     - cdsapi
-    - git+https://github.com/absolute-afloat/atlite.git@hr


### PR DESCRIPTION
Also comes with an updated Zenodo repository (v1.2.3).