### PR TITLE
[Tweak] Fix EV notebook for GB/UK

### DIFF
--- a/workflow/notebooks/highRES_build_ev_inputs.ipynb
+++ b/workflow/notebooks/highRES_build_ev_inputs.ipynb
@@ -91,7 +91,7 @@
     "    'ES':1,\n",
     "    'SE':1,\n",
     "    'CH':1,\n",
-    "    'GB':0,\n",
+    "    'UK':0,\n",
     "})"
    ]
   },
@@ -255,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When testing the workflow more thoroughly, I noticed that the EV notebook crashed when running with all countries. It appears to be a mismatch between GB/UK for the new summer-time/time zone awareness that was implemented. 

Simply renaming GB to UK should do the trick. 